### PR TITLE
fix 404 error if assigned user is empty

### DIFF
--- a/lib/auto_watchers_from_groups.rb
+++ b/lib/auto_watchers_from_groups.rb
@@ -16,17 +16,10 @@ module AutoWatchersFromGroups
 			@issue = Issue.find context[:issue]
 
 			if context[:params][:issue]
-
-				# normal group assign
-				if @settings['groups_enabled'].include? context[:params][:issue][:assigned_to_id]
-					group = Group.find context[:params][:issue][:assigned_to_id]
-				end
-
-				# group assign with category default assignee
-				@project = context[:params][:project_id]
-				@project = context[:params][:issue][:project_id] if context[:params][:issue][:project_id]
-
 				if context[:params][:issue][:assigned_to_id].blank?
+					# group assign with category default assignee
+					@project = context[:params][:project_id]
+					@project = context[:params][:issue][:project_id] if context[:params][:issue][:project_id]
 					unless context[:params][:issue][:category_id].blank?
 						if context[:params][:commit] == "Create"
 							if @settings['groups_enabled'].include? group_id = Project.find(@project).issue_categories.find_by_id(context[:params][:issue][:category_id]).assigned_to_id.to_s
@@ -34,6 +27,9 @@ module AutoWatchersFromGroups
 							end
 						end
 					end
+				elsif @settings['groups_enabled'].include? context[:params][:issue][:assigned_to_id]
+					# normal group assign
+					group = Group.find context[:params][:issue][:assigned_to_id]
 				end
 
 				unless group.nil?


### PR DESCRIPTION
If _Assignee_ field is empty plugin returns 404 error. This hook should work only if id is not blank

ActiveRecord::RecordNotFound (Couldn't find Group with id= [WHERE `users`.`type` IN ('Group')]):
  lib/redmine/hook.rb:61:in `block (2 levels) in call_hook'
  lib/redmine/hook.rb:61:in`each'
  lib/redmine/hook.rb:61:in `block in call_hook'
  lib/redmine/hook.rb:58:in`tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:153:in`call_hook'
  app/controllers/issues_controller.rb:469:in `block in save_issue_with_child_records'
  app/controllers/issues_controller.rb:458:in`save_issue_with_child_records'
  app/controllers/issues_controller.rb:184:in `update'
